### PR TITLE
Convert from python to rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+*.code-workspace
+.idea/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DiscordProjectSettings">
-    <option name="show" value="ASK" />
-    <option name="description" value="" />
-  </component>
-</project>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,13 +140,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "cc"
-version = "1.0.94"
+name = "byteorder-lite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -358,11 +365,11 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a84a25dcae3ac487bc24ef280f9e20c79c9b1a3e5e32cbed3041d1c514aa87c"
+checksum = "d730b085583c4d789dfd07fdcf185be59501666a90c97c40162b37e4fdad272d"
 dependencies = [
- "byteorder",
+ "byteorder-lite",
  "thiserror",
 ]
 
@@ -768,9 +775,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -1032,18 +1039,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1110,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,18 +1158,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1203,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "jdjg-image-manipulation"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+description = "Image manipulation library for the JDJG organization"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,17 +163,17 @@ fn call_text(mut text: String) -> Vec<u8> {
     // call_text stuff.
 }
 
-fn laugh_frame() -> Vec<u8> {
-    //TODO: Create laugh frame function
-}
+// fn laugh_frame() -> Vec<u8> {
+//     //TODO: Create laugh frame function
+// }
 
-unsafe fn laugh(raw_asset: Vec<u8>) -> Vec<u8> {
-    let buff = Cursor::new(Vec::new());
-    let laugh = ImageReader::open(Path::new("./assets/images/laugh.png")).unwrap().decode().unwrap().to_rgba8(); 
-    let asset = ImageReader::new(Cursor::new(raw_asset)).with_guessed_format().unwrap().decode().unwrap();   
-    // TODO: how to look is the asset is animated
-    
-}
+// unsafe fn laugh(raw_asset: Vec<u8>) -> Vec<u8> {
+//     let buff = Cursor::new(Vec::new());
+//     let laugh = ImageReader::open(Path::new("./assets/images/laugh.png")).unwrap().decode().unwrap().to_rgba8(); 
+//     let asset = ImageReader::new(Cursor::new(raw_asset)).with_guessed_format().unwrap().decode().unwrap();   
+//     // TODO: how to look is the asset is animated
+
+// }
 
 
 // both laugh stuff

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,19 @@
+use std::convert::TryInto;
 use ab_glyph::{Font, FontRef, PxScale};
-use image::io::Reader as ImageReader;
+use image::io::{Reader as ImageReader, Reader};
 use image::{imageops, ImageError, ImageFormat, Rgba};
 use std::io::Cursor;
+use std::path::Path;
+use pyo3::impl_::wrap::SomeWrap;
 use textwrap::fill;
 
 fn main() {
 
+    println!("{}", wrap_text("Test", Some(2)));
+    
+    gadget("Test".to_string());
+    println!("Test: {:?}", Rgba([255u8, 255u8, 255u8, 255u8]).wrap().unwrap());
+    
     // should be write an if statement and the else statement.
 
     //crusty();
@@ -86,19 +94,21 @@ fn gadget(mut text: String) -> Vec<u8> {
     let font = FontRef::try_from_slice(include_bytes!("../assets/fonts/verdana_edited.ttf")).unwrap();
     // idk the import for this.
 
-    text = wrap_text(text.to_uppercase().as_str(), None);
+    text = wrap_text(text.to_uppercase().as_str(), Some(4));
     // Needing to pass None is a little annoying.
 
     let mut final_bytes: Vec<u8> = Vec::new();
     // let error_img = ImageReader::open("../assets/images/bad_output.png")?.decode()?;
-    let gadget_img = ImageReader::open("../assets/images/gadget.png")
-        .unwrap()
-        .decode()
+    let gadget_img = ImageReader::open(Path::new("./assets/images/gadget.png"))
         .unwrap();
-
     // gadget_img.write_to(&mut Cursor::new(&mut final_bytes));
-    // how do I get the ImageFormat for it?
+    // how do I get the ImageFormat for it
+    
+    let gadget_format = gadget_img.format().unwrap();
+    let gadget_img = gadget_img.decode().unwrap();
 
+    gadget_img.write_to(&mut Cursor::new(&mut final_bytes), gadget_format).expect("TODO: panic message");
+    
     // gadget code
     // https://github.com/JDsProjects/JDBot/blob/0e5d2f5543b2ae0951aeb8824efd51e0da7ec739/utils/image.py#L36
 
@@ -113,6 +123,7 @@ fn invert(image_bytes: Vec<u8>) -> Vec<u8> {
         .unwrap()
         .decode()
         .unwrap();
+    
     img.invert();
     // you need to make all unwrap into error handling like crusty btw.
 
@@ -125,7 +136,6 @@ fn invert(image_bytes: Vec<u8>) -> Vec<u8> {
 }
 
 fn call_text(mut text: String) -> Vec<u8> {
-
     text = fill(text.as_str(), 33);
 
     let mut final_bytes: Vec<u8> = Vec::new();
@@ -225,17 +235,17 @@ def laugh2(raw_asset: bytes) -> tuple[BytesIO, typing.Literal["gif", "png"]]:
 */
 
 /*
-petpet function.
-I think that's
-https://github.com/JDsProjects/JDBot/blob/master/utils/image.py
-
-https://github.com/JDsProjects/RenDev-s-PIL-program
-(petpet original might refer to newer copies from people that I can license from ie MIT OR MPL)
-This is licensed under the JDJG's Programs project and agreed to allow me to use it under the license that i Have so.
-
-Remeber rewrite stuff and delete stuff that isn't releveant ie all functions except invert2 unless you want to try to use two functions.
-Invert -> one way
-Invert2 - > different way
-Might even try writing pillow code to wand like gadget and whatnot to see how it would be.
-But this may work better completly in rust so.
+    petpet function.
+    I think that's
+    https://github.com/JDsProjects/JDBot/blob/master/utils/image.py
+    
+    https://github.com/JDsProjects/RenDev-s-PIL-program
+    (petpet original might refer to newer copies from people that I can license from ie MIT OR MPL)
+    This is licensed under the JDJG's Programs project and agreed to allow me to use it under the license that i Have so.
+    
+    Remeber rewrite stuff and delete stuff that isn't releveant ie all functions except invert2 unless you want to try to use two functions.
+    Invert -> one way
+    Invert2 - > different way
+    Might even try writing pillow code to wand like gadget and whatnot to see how it would be.
+    But this may work better completly in rust so.
 */


### PR DESCRIPTION
In this PR Draft there is some functions, which was converted from Python to Rust.


- [x] call_text()
- [ ] wrap_text‎()
- [ ] gadget()
- [ ] invert()
- [ ] invert2()
- [ ] laugh()
- [ ] laugh2()
- [ ] crusty()